### PR TITLE
extend plugin to support dynamic port pool

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,12 @@
       <id>oldelvet</id>
       <name>Richard Mortimer</name>
     </developer>
+    <developer>
+      <id>pepov</id>
+      <name>Peter Wilcsinszky</name>
+    </developer>
   </developers>
+
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/port-allocator-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/port-allocator-plugin.git</developerConnection>
@@ -45,6 +50,4 @@
             <url>http://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-</project>  
-  
-
+</project>

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/PluginImpl.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/PluginImpl.java
@@ -12,6 +12,7 @@ public class PluginImpl extends Plugin {
     @Override
     public void start() throws Exception {
         PortTypeDescriptor.LIST.add(DefaultPortType.DescriptorImpl.INSTANCE);
+        PortTypeDescriptor.LIST.add(PooledPortType.DescriptorImpl.INSTANCE);
         PortTypeDescriptor.LIST.add(GlassFishJmxPortType.DescriptorImpl.INSTANCE);
         PortTypeDescriptor.LIST.add(TomcatShutdownPortType.DescriptorImpl.INSTANCE);
     }

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/Pool.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/Pool.java
@@ -1,0 +1,25 @@
+package org.jvnet.hudson.plugins.port_allocator;
+
+/**
+ * Represents a port pool.
+ *
+ * @author pepov
+ */
+public class Pool {
+    
+    public String name;
+    public String ports;
+
+    public int[] getPortsAsInt() {
+
+        String[] portsItemsAsString = ports.split(",");
+
+        int[] portsItems = new int[portsItemsAsString.length];
+
+        for (int i = 0; i < portsItemsAsString.length; i++) {
+            portsItems[i] = Integer.parseInt(portsItemsAsString[i]);
+        }
+
+        return portsItems;
+    }
+}

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/PoolNotDefinedException.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/PoolNotDefinedException.java
@@ -1,0 +1,7 @@
+package org.jvnet.hudson.plugins.port_allocator;
+
+/**
+ * @author pepov
+ */
+public class PoolNotDefinedException extends Throwable {
+}

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/PooledPort.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/PooledPort.java
@@ -1,0 +1,32 @@
+package org.jvnet.hudson.plugins.port_allocator;
+
+import java.io.IOException;
+
+/**
+ * Represents a port, that has been allocated from a pool.
+ *
+ * Holds a PortAllocationManager to trigger cleanup.
+ *
+ * @author pepov
+ */
+public class PooledPort extends Port {
+
+	private int selectedPort;
+	private PortAllocationManager manager;
+
+	public PooledPort(PooledPortType portType, int selectedPort, PortAllocationManager manager) {
+		super(portType);
+		this.selectedPort = selectedPort;
+		this.manager = manager;
+	}
+
+	@Override
+	public int get() {
+		return selectedPort;
+	}
+	
+	@Override
+	public void cleanUp() throws IOException, InterruptedException {
+		manager.free(selectedPort);
+	}
+}

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/PooledPortType.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/PooledPortType.java
@@ -1,0 +1,102 @@
+package org.jvnet.hudson.plugins.port_allocator;
+
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.util.ListBoxModel;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
+
+import java.io.IOException;
+
+/**
+ * Port type for representing a pool of ports used concurrently by parallel jobs
+ *
+ * @author pepov
+ */
+public class PooledPortType extends PortType {
+
+    private int[] pool;
+
+    @DataBoundConstructor
+    public PooledPortType(String name) {
+        super(name);
+    }
+
+    /**
+     * Try to allocate one free port from the given pool.
+     * Wait for a short period if no free port is available, then try again.
+     */
+    @Override
+    public Port allocate(
+        AbstractBuild<?, ?> build,
+        final PortAllocationManager manager,
+        int prefPort,
+        Launcher launcher,
+        BuildListener buildListener
+    ) throws IOException, InterruptedException {
+
+        try {
+            while (true) {
+
+                Pool pool = PortAllocator.DESCRIPTOR.getPoolByName(name);
+
+                synchronized (pool) {
+                    for (int port : pool.getPortsAsInt()) {
+                        if (manager.isFree(port)) {
+                            manager.allocate(build, port);
+                            return new PooledPort(this, port, manager);
+                        }
+                    }
+                    pool.wait(500);
+                }
+            }
+        } catch (PoolNotDefinedException e) {
+            throw new RuntimeException("Undefined pool: " + name);
+        }
+    }
+
+    @Override
+    public DescriptorImpl getDescriptor() {
+        return DescriptorImpl.INSTANCE;
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends PortTypeDescriptor {
+
+        public DescriptorImpl() {
+            super(PooledPortType.class);
+        }
+
+        public PooledPortType newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+
+            if ("".equals(formData.getString("name"))) {
+                throw new FormException(
+                    "Unable to setup port allocator for an undefined pool!" +
+                      " Please configure pools in the global configuration settings!",
+                    "name"
+                );
+            }
+
+            return new PooledPortType(
+                formData.getString("name")
+            );
+        }
+
+        public String getDisplayName() {
+            return "Pooled TCP port";
+        }
+
+        public ListBoxModel doFillNameItems() {
+            ListBoxModel model = new ListBoxModel();
+            for (Pool p : PortAllocator.DESCRIPTOR.getPools()) {
+                model.add(p.name, p.name);
+            }
+            return model;
+        }
+
+        public static final DescriptorImpl INSTANCE = new DescriptorImpl();
+    }
+}

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortAllocationManager.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortAllocationManager.java
@@ -100,6 +100,14 @@ public final class PortAllocationManager {
         return port;
     }
 
+	public synchronized boolean isFree(int port) {
+		AbstractBuild owner = ports.get(port);
+		if (owner == null) {
+			return true;
+		}
+		return false;
+	}
+
     public static PortAllocationManager getManager(Computer node) {
         PortAllocationManager pam;
         WeakReference<PortAllocationManager> ref = INSTANCES.get(node);

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortAllocator.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortAllocator.java
@@ -2,38 +2,34 @@ package org.jvnet.hudson.plugins.port_allocator;
 
 import hudson.Extension;
 import hudson.Launcher;
-import hudson.model.BuildListener;
-import hudson.model.Computer;
-import hudson.model.Descriptor;
-import hudson.model.Executor;
-import hudson.model.AbstractBuild;
+import hudson.model.*;
 import hudson.tasks.BuildWrapper;
+import hudson.util.FormValidation;
 import net.sf.json.JSONObject;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.regex.Pattern;
 
 /**
  * Allocates TCP Ports on a Computer for consumption and sets it as
- * envioronet variables, see configuration
+ * environment variables, see configuration
  *
  * <p>
  * This just mediates between different Jobs running on the same Computer
  * by assigning free ports and its the jobs responsibility to open and close the ports.   
  *
- * <p>
- * TODO: implement ResourceActivity so that the queue performs intelligent job allocations
- * based on the port availability, instead of start executing something then block.
- *
  * @author Rama Pulavarthi
  */
-public class PortAllocator extends BuildWrapper /* implements ResourceActivity */
+public class PortAllocator extends BuildWrapper implements ResourceActivity
 {
+    private static final Log log = LogFactory.getLog(PortAllocator.class);
+
     public final PortType[] ports;
 
     private PortAllocator(PortType[] ports){
@@ -87,6 +83,38 @@ public class PortAllocator extends BuildWrapper /* implements ResourceActivity *
         };
     }
 
+    public ResourceList getResourceList() {
+        ResourceList resourceList = new ResourceList();
+        for (PortType portType : ports) {
+            if (portType instanceof PooledPortType) {
+                try {
+                    addResource(resourceList, (PooledPortType) portType, DESCRIPTOR.getPoolSize(portType.name));
+                } catch (PoolNotDefinedException e) {
+                    log.warn("Unable to add resource", e);
+                }
+            } else {
+                addResource(resourceList, portType, 1);
+            }
+        }
+        return resourceList;
+    }
+
+    private void addResource(ResourceList resourceList, PooledPortType portType, int count) {
+        resourceList.w(
+            new Resource(null, "port pool " + portType.name, count)
+        );
+    }
+
+    private void addResource(ResourceList resourceList, PortType portType, int count) {
+        resourceList.w(
+            new Resource(null, "standalone port " + portType.name, count)
+        );
+    }
+
+    public String getDisplayName() {
+        return "Port exclusion";
+    }
+
     @Override
     public Descriptor<BuildWrapper> getDescriptor() {
         return DESCRIPTOR;
@@ -96,7 +124,10 @@ public class PortAllocator extends BuildWrapper /* implements ResourceActivity *
     public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
 
     public static final class DescriptorImpl extends Descriptor<BuildWrapper> {
-        DescriptorImpl() {
+
+        private Pool[] pools = new Pool[] {};
+
+        public DescriptorImpl() {
             super(PortAllocator.class);
             load();
         }
@@ -118,8 +149,84 @@ public class PortAllocator extends BuildWrapper /* implements ResourceActivity *
         public BuildWrapper newInstance(StaplerRequest req, JSONObject formData) throws FormException {
             List<PortType> ports = Descriptor.newInstancesFromHeteroList(
                     req, formData, "ports", PortTypeDescriptor.LIST);
+
+            HashSet<String> portNames = new HashSet<String>();
+
+            for (PortType p : ports) {
+                if (!portNames.add(p.name)) {
+                    throw new FormException("Cannot add multiple port allocators with the same name!", "name");
+                }
+            }
+
             return new PortAllocator(ports.toArray(new PortType[ports.size()]));
         }
-    }
 
+        @Override
+        public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
+            Pool[] pools = req.bindParametersToList(Pool.class, "pool.").toArray(new Pool[] {});
+            for (Pool p : pools) {
+                p.name = checkPoolName(p.name);
+                checkPortNumbers(p.ports);
+            }
+            this.pools = pools;
+            save();
+            return super.configure(req,formData);
+        }
+
+        public FormValidation doCheckPort(@QueryParameter("value") final String ports) {
+            try {
+                checkPortNumbers(ports);
+                return FormValidation.ok();
+            } catch (FormException e) {
+                return FormValidation.error(e.getMessage());
+            }
+        }
+
+        public FormValidation doCheckName(@QueryParameter("value") final String name) {
+            try {
+                checkPoolName(name);
+                return FormValidation.ok();
+            } catch (FormException e) {
+                return FormValidation.error(e.getMessage());
+            }
+        }
+
+        private String checkPoolName(String name) throws FormException {
+
+            if ("".equals(name)) {
+                throw new FormException("Pool name must not be empty", "name");
+            }
+
+            if (Pattern.matches("\\w+", name)) {
+                return name.toUpperCase();
+            } else {
+                throw new FormException(
+                    "The name: \"" + name + "\" is invalid! It must not contain other than word characters!", "name"
+                );
+            }
+        }
+
+        private void checkPortNumbers(String ports) throws FormException {
+            if (!Pattern.matches("(\\d+,)*\\d+", ports)) {
+                throw new FormException("Need a comma separated list of port numbers", "ports");
+            }
+        }
+
+        public Pool[] getPools() {
+            return pools;
+        }
+
+        public Pool getPoolByName(String poolName) throws PoolNotDefinedException {
+            for (Pool p : pools) {
+                if (p.name.toUpperCase().equals(poolName.toUpperCase())) {
+                    return p;
+                }
+            }
+            throw new PoolNotDefinedException();
+        }
+
+        public int getPoolSize(String poolName) throws PoolNotDefinedException {
+            return getPoolByName(poolName).getPortsAsInt().length;
+        }
+    }
 }

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortTypeDescriptor.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortTypeDescriptor.java
@@ -17,14 +17,6 @@ public abstract class PortTypeDescriptor extends Descriptor<PortType> {
     }
 
     /**
-     * Unused.
-     */
-    @Override
-    public final PortType newInstance(StaplerRequest req) throws FormException {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
      * All registered {@link PortTypeDescriptor}s.
      */
     public static final List<PortTypeDescriptor> LIST = new ArrayList<PortTypeDescriptor>();

--- a/src/main/resources/org/jvnet/hudson/plugins/port_allocator/PooledPortType/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/port_allocator/PooledPortType/config.jelly
@@ -1,0 +1,11 @@
+<j:jelly
+        xmlns:j="jelly:core"
+        xmlns:st="jelly:stapler"
+        xmlns:d="jelly:define"
+        xmlns:l="/lib/layout"
+        xmlns:t="/lib/hudson"
+        xmlns:f="/lib/form">
+    <f:entry title="Pool name" field="name" help="/plugin/port-allocator/help-pool-select.html">
+        <f:select />
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/org/jvnet/hudson/plugins/port_allocator/PortAllocator/global.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/port_allocator/PortAllocator/global.jelly
@@ -1,5 +1,24 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <!--
-    No Global configuration
-  -->  
+<j:jelly xmlns:j="jelly:core"
+         xmlns:st="jelly:stapler"
+         xmlns:d="jelly:define"
+         xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson"
+         xmlns:f="/lib/form">
+    <f:section title="Port allocator configuration">
+        <f:entry title="Pool definitions">
+            <f:repeatable var="pool" items="${descriptor.pools}">
+                <table width="100%">
+                    <f:entry title="Name" help="/plugin/port-allocator/help-pool-definition-name.html">
+                        <f:textbox name="pool.name" value="${pool.name}"
+                            checkUrl="'descriptorByName/PortAllocator/checkName?value='+this.value" />
+                    </f:entry>
+                    <f:entry title="Ports" help="/plugin/port-allocator/help-pool-definition-ports.html">
+                        <f:textbox name="pool.ports" value="${pool.ports}"
+                            checkUrl="'descriptorByName/PortAllocator/checkPort?value='+this.value" />
+                    </f:entry>
+                    <f:entry><f:repeatableDeleteButton /></f:entry>
+                </table>
+            </f:repeatable>
+        </f:entry>
+    </f:section>
 </j:jelly>

--- a/src/main/webapp/help-pool-definition-name.html
+++ b/src/main/webapp/help-pool-definition-name.html
@@ -1,0 +1,5 @@
+<div>
+    <p>
+        The name of the pool will be used as the exported environment variable name holding the allocated port number.
+    </p>
+</div>

--- a/src/main/webapp/help-pool-definition-ports.html
+++ b/src/main/webapp/help-pool-definition-ports.html
@@ -1,0 +1,5 @@
+<div>
+    <p>
+        Please define a comma separated list of port numbers, that will be allocated to concurrent jobs.
+    </p>
+</div>

--- a/src/main/webapp/help-pool-select.html
+++ b/src/main/webapp/help-pool-select.html
@@ -1,0 +1,5 @@
+<div>
+    <p>
+        Pool definitions can be configured globally at the "Port allocator configuration" section.
+    </p>
+</div>


### PR DESCRIPTION
This is an extension to the plugin, that allows jobs to depend on a pool of predefined ports. 
- If there are free ports in a pool, a build can aquire one of them and start execution. 
- When there are no more free ports in the pool, the subsequent builds are queued up, waiting for the ongoing builds to finish.
