### PR TITLE
[FIXED JENKINS-18786] Port allocation blocks jobs from executing concurr...

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortAllocator.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortAllocator.java
@@ -92,8 +92,6 @@ public class PortAllocator extends BuildWrapper implements ResourceActivity
                 } catch (PoolNotDefinedException e) {
                     log.warn("Unable to add resource", e);
                 }
-            } else {
-                addResource(resourceList, portType, 1);
             }
         }
         return resourceList;


### PR DESCRIPTION
...ently

The fix for JENKINS-11255 uses Resources to block the execution of jobs
requiring the same port configuration. However this does not take into
account the node that the port is to be reserved on and also ranges of
ports. Revert to the old behaviour for all but pooled ports.
