### PR TITLE
Support for a global pool of port numbers

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/Pool.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/Pool.java
@@ -6,20 +6,21 @@ package org.jvnet.hudson.plugins.port_allocator;
  * @author pepov
  */
 public class Pool {
-    
-    public String name;
-    public String ports;
 
-    public int[] getPortsAsInt() {
+	public boolean global;
+	public String name;
+	public String ports;
 
-        String[] portsItemsAsString = ports.split(",");
+	public int[] getPortsAsInt() {
 
-        int[] portsItems = new int[portsItemsAsString.length];
+		String[] portsItemsAsString = ports.split(",");
 
-        for (int i = 0; i < portsItemsAsString.length; i++) {
-            portsItems[i] = Integer.parseInt(portsItemsAsString[i]);
-        }
+		int[] portsItems = new int[portsItemsAsString.length];
 
-        return portsItems;
-    }
+		for (int i = 0; i < portsItemsAsString.length; i++) {
+			portsItems[i] = Integer.parseInt(portsItemsAsString[i]);
+		}
+
+		return portsItems;
+	}
 }

--- a/src/main/resources/org/jvnet/hudson/plugins/port_allocator/PortAllocator/global.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/port_allocator/PortAllocator/global.jelly
@@ -8,6 +8,9 @@
         <f:entry title="Pool definitions">
             <f:repeatable var="pool" items="${descriptor.pools}">
                 <table width="100%">
+                	<f:entry title="Global" help="/plugin/port-allocator/help-pool-definition-global.html">
+                		<f:checkbox name="pool.global" checked="${pool.global}"/>
+                	</f:entry>
                     <f:entry title="Name" help="/plugin/port-allocator/help-pool-definition-name.html">
                         <f:textbox name="pool.name" value="${pool.name}"
                             checkUrl="'descriptorByName/PortAllocator/checkName?value='+this.value" />

--- a/src/main/webapp/help-pool-definition-global.html
+++ b/src/main/webapp/help-pool-definition-global.html
@@ -1,0 +1,5 @@
+<div>
+    <p>
+        Should this pool allocate unique port numbers globally or per node.
+    </p>
+</div>


### PR DESCRIPTION
Make it possible to generate unique port numbers for the entire Jenkins cluster instead of unique port numbers per node.
Use case: jobs running on different Jenkins nodes can start an application container for integration testing on the same remote host. The application container is supplied by a Docker container and is started on a Docker cluster.