### PR TITLE
Don't enforce upper case for variables.

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortAllocator.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortAllocator.java
@@ -169,13 +169,13 @@ public class PortAllocator extends BuildWrapper
                 throw new FormException("Pool name must not be empty", "name");
             }
 
-            if (Pattern.matches("\\w+", name)) {
-                return name.toUpperCase();
-            } else {
+            if (!Pattern.matches("\\w+", name)) {
                 throw new FormException(
-                    "The name: \"" + name + "\" is invalid! It must not contain other than word characters!", "name"
+                        "The name: \"" + name + "\" is invalid! It must not contain other than word characters!", "name"
                 );
             }
+
+            return name;
         }
 
         private void checkPortNumbers(String ports) throws FormException {
@@ -190,7 +190,7 @@ public class PortAllocator extends BuildWrapper
 
         public Pool getPoolByName(String poolName) throws PoolNotDefinedException {
             for (Pool p : pools) {
-                if (p.name.toUpperCase().equals(poolName.toUpperCase())) {
+                if (p.name.equals(poolName)) {
                     return p;
                 }
             }

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortType.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortType.java
@@ -27,9 +27,7 @@ public abstract class PortType implements ExtensionPoint, Describable<PortType>,
     public final String name;
 
     protected PortType(String name) {
-        // to avoid platform difference issue in case sensitivity of environment variables,
-        // always use uppser case.
-        this.name = name.toUpperCase();
+        this.name = name;
     }
 
     /**


### PR DESCRIPTION
If you have software that expects lower case variable, then you are unable to use this plugin at all.