### PR TITLE
Added workflow/pipeline support for pooled ports.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.424</version>
+    <version>1.609.1</version>
   </parent>
 
   <artifactId>port-allocator</artifactId>
@@ -29,7 +29,14 @@
       <id>pepov</id>
       <name>Peter Wilcsinszky</name>
     </developer>
+    <developer>
+      <name>Jens Mittag</name>
+    </developer>
   </developers>
+
+  <properties>
+    <workflow.version>1.8</workflow.version>
+  </properties>
 
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/port-allocator-plugin.git</connection>
@@ -60,6 +67,57 @@
 
     <dependencies>
       <dependency>
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-job</artifactId>
+        <version>${workflow.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-basic-steps</artifactId>
+        <version>${workflow.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-cps</artifactId>
+        <version>${workflow.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-durable-task-step</artifactId>
+        <version>${workflow.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency> <!-- StepConfigTester -->
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-step-api</artifactId>
+        <version>${workflow.version}</version>
+        <classifier>tests</classifier>
+        <scope>test</scope>
+      </dependency>
+      <dependency> <!-- JenkinsRuleExt -->
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-aggregator</artifactId>
+        <version>${workflow.version}</version>
+        <classifier>tests</classifier>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.modules</groupId>
+        <artifactId>sshd</artifactId>
+        <version>1.6</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-all</artifactId>
+        <version>1.9.0-rc1</version>
+        <type>jar</type>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-all</artifactId>
         <version>1.9.0-rc1</version>
@@ -67,4 +125,4 @@
         <scope>test</scope>
       </dependency>
     </dependencies>
-</project>  
+</project>

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/DefaultPortType.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/DefaultPortType.java
@@ -1,8 +1,9 @@
 package org.jvnet.hudson.plugins.port_allocator;
 
-import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.Launcher;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
@@ -22,13 +23,15 @@ public class DefaultPortType extends PortType {
     }
 
     @Override
-    public Port allocate(AbstractBuild<?, ?> build, final PortAllocationManager manager, int prefPort, Launcher launcher, BuildListener buildListener) throws IOException, InterruptedException {
+    public Port allocate(Run<?, ?> run, final PortAllocationManager manager, int prefPort, Launcher launcher, TaskListener taskListener)
+        throws IOException, InterruptedException
+    {
         final int n;
         if(isFixedPort())
-            n = manager.allocate(build, getFixedPort());
+            n = manager.allocate(run, getFixedPort());
         else
-            n = manager.allocateRandom(build, prefPort);
-        
+            n = manager.allocateRandom(run, prefPort);
+
         return new Port(this) {
             public int get() {
                 return n;

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/PooledPortType.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/PooledPortType.java
@@ -2,8 +2,9 @@ package org.jvnet.hudson.plugins.port_allocator;
 
 import hudson.Extension;
 import hudson.Launcher;
-import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.util.ListBoxModel;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -30,23 +31,14 @@ public class PooledPortType extends PortType {
      * Wait for a short period if no free port is available, then try again.
      */
     @Override
-    public Port allocate(
-        AbstractBuild<?, ?> build,
-        final PortAllocationManager manager,
-        int prefPort,
-        Launcher launcher,
-        BuildListener buildListener
-    ) throws IOException, InterruptedException {
-
+    public Port allocate(Run<?, ?> run, PortAllocationManager manager, int prefPort, Launcher launcher, TaskListener taskListener) throws IOException, InterruptedException {
         try {
             while (true) {
-
                 Pool pool = PortAllocator.DESCRIPTOR.getPoolByName(name);
-
                 synchronized (pool) {
                     for (int port : pool.getPortsAsInt()) {
                         if (manager.isFree(port)) {
-                            manager.allocate(build, port);
+                            manager.allocate(run, port);
                             return new PooledPort(this, port, manager);
                         }
                     }

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/Port.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/Port.java
@@ -1,13 +1,14 @@
 package org.jvnet.hudson.plugins.port_allocator;
 
 import java.io.IOException;
+import java.io.Serializable;
 
 /**
  * Represents an assigned TCP port and encapsulates how it should be cleaned up.
  * 
  * @author Kohsuke Kawaguchi
  */
-public abstract class Port {
+public abstract class Port implements Serializable {
     /**
      * {@link PortType} that created this port.
      */

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortAllocator.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortAllocator.java
@@ -1,13 +1,17 @@
 package org.jvnet.hudson.plugins.port_allocator;
 
+import hudson.EnvVars;
 import hudson.Extension;
+import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.*;
 import hudson.tasks.BuildWrapper;
+import jenkins.tasks.SimpleBuildWrapper;
 import hudson.util.FormValidation;
 import net.sf.json.JSONObject;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -22,11 +26,11 @@ import java.util.regex.Pattern;
  *
  * <p>
  * This just mediates between different Jobs running on the same Computer
- * by assigning free ports and its the jobs responsibility to open and close the ports.   
+ * by assigning free ports and its the jobs responsibility to open and close the ports.
  *
  * @author Rama Pulavarthi
  */
-public class PortAllocator extends BuildWrapper
+public class PortAllocator extends SimpleBuildWrapper
 {
     private static final Log log = LogFactory.getLog(PortAllocator.class);
 
@@ -36,14 +40,21 @@ public class PortAllocator extends BuildWrapper
         this.ports = ports;
     }
 
-    @Override
-    public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
-        PrintStream logger = listener.getLogger();
+    @DataBoundConstructor
+    public PortAllocator(String pool) {
+        List<PortType> ports = new ArrayList<PortType>();
+        ports.add(new PooledPortType(pool));
+        this.ports = ports.toArray(new PortType[ports.size()]);
+    }
 
-        final Computer cur = Executor.currentExecutor().getOwner();
+    @Override
+    public void setUp(Context context, Run<?, ?> run, FilePath workspace, Launcher launcher, TaskListener taskListener, EnvVars envVars) throws IOException, InterruptedException {
+        PrintStream logger = taskListener.getLogger();
+
+        Computer cur = workspace.toComputer();
         Map<String,Integer> prefPortMap = new HashMap<String,Integer>();
-        if (build.getPreviousBuild() != null) {
-            AllocatedPortAction prevAlloc = build.getPreviousBuild().getAction(AllocatedPortAction.class);
+        if (run.getPreviousBuild() != null) {
+            AllocatedPortAction prevAlloc = run.getPreviousBuild().getAction(AllocatedPortAction.class);
             if (prevAlloc != null) {
                 // try to assign ports assigned in previous build
                 prefPortMap = prevAlloc.getPreviousAllocatedPorts();
@@ -56,31 +67,19 @@ public class PortAllocator extends BuildWrapper
         for (PortType pt : ports) {
             logger.println("Allocating TCP port "+pt.name);
             int prefPort = prefPortMap.get(pt.name)== null?0:prefPortMap.get(pt.name);
-            Port p = pt.allocate(build, pam, prefPort, launcher, listener);
+            Port p = pt.allocate(run, pam, prefPort, launcher, taskListener);
             allocated.add(p);
-            portMap.put(pt.name,p.get());
+            portMap.put(pt.name, p.get());
             logger.println("  -> Assigned "+p.get());
         }
 
         // TODO: only log messages when we are blocking.
         logger.println("TCP port allocation complete");
-        build.addAction(new AllocatedPortAction(portMap));
+        run.addAction(new AllocatedPortAction(portMap));
 
-        return new Environment() {
-
-            @Override
-            public void buildEnvVars(Map<String, String> env) {
-                for (Port p : allocated)
-                    env.put(p.type.name, String.valueOf(p.get()));
-            }
-
-            @Override
-            public boolean tearDown(AbstractBuild build, BuildListener listener) throws IOException, InterruptedException {
-                for (Port p : allocated)
-                    p.cleanUp();
-                return true;
-            }
-        };
+        context.setDisposer(new CleanupDisposer(allocated));
+        for (Port p : allocated)
+            context.env(p.type.name, String.valueOf(p.get()));
     }
 
     public String getDisplayName() {
@@ -97,7 +96,7 @@ public class PortAllocator extends BuildWrapper
 
     public static final class DescriptorImpl extends Descriptor<BuildWrapper> {
 
-        private Pool[] pools = new Pool[] {};
+        private List<Pool> pools = new ArrayList<Pool>();
 
         public DescriptorImpl() {
             super(PortAllocator.class);
@@ -114,7 +113,7 @@ public class PortAllocator extends BuildWrapper
         }
 
         public List<PortTypeDescriptor> getPortTypes() {
-            return PortTypeDescriptor.LIST; 
+            return PortTypeDescriptor.LIST;
         }
 
         @Override
@@ -139,8 +138,8 @@ public class PortAllocator extends BuildWrapper
             for (Pool p : pools) {
                 p.name = checkPoolName(p.name);
                 checkPortNumbers(p.ports);
+                this.pools.add(p);
             }
-            this.pools = pools;
             save();
             return super.configure(req,formData);
         }
@@ -184,7 +183,7 @@ public class PortAllocator extends BuildWrapper
             }
         }
 
-        public Pool[] getPools() {
+        public List<Pool> getPools() {
             return pools;
         }
 
@@ -199,6 +198,21 @@ public class PortAllocator extends BuildWrapper
 
         public int getPoolSize(String poolName) throws PoolNotDefinedException {
             return getPoolByName(poolName).getPortsAsInt().length;
+        }
+    }
+
+    private static class CleanupDisposer extends Disposer {
+
+        List<Port> allocated;
+
+        public CleanupDisposer(List<Port> allocated) {
+            this.allocated = allocated;
+        }
+
+        @Override
+        public void tearDown(Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
+            for (Port p : allocated)
+                p.cleanUp();
         }
     }
 }

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortType.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortType.java
@@ -2,9 +2,10 @@ package org.jvnet.hudson.plugins.port_allocator;
 
 import hudson.ExtensionPoint;
 import hudson.Launcher;
-import hudson.model.AbstractBuild;
 import hudson.model.Describable;
 import hudson.model.BuildListener;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -53,15 +54,15 @@ public abstract class PortType implements ExtensionPoint, Describable<PortType>,
 
     /**
      * Allocates a new port for a given build.
-     *
+     * @param run
+     *      The current build
      * @param manager
      *      This can be used to assign a new TCP port number.
      * @param prefPort
      *  The port number allocated to this type the last time.
      * @param launcher
-     * @param buildListener
      */
-    public abstract Port allocate(AbstractBuild<?, ?> build, PortAllocationManager manager, int prefPort, Launcher launcher, BuildListener buildListener) throws IOException, InterruptedException;
+    public abstract Port allocate(Run<?, ?> run, PortAllocationManager manager, int prefPort, Launcher launcher, TaskListener taskListener) throws IOException, InterruptedException;
 
     public abstract PortTypeDescriptor getDescriptor();
 


### PR DESCRIPTION
This is a set of changes that make the port-allocator plugin compatible with the workflow API. I don't know whether evyrthing is 100% correct (this is my first work on a Jenkins plugin), but on my instance everything works as expected. 

Usage:
```
wrap([$class: 'PortAllocator', pool: 'POOLNAME']) {
}
```

So far, I only added support for Pooled Ports (from within the pipeline). The changes also make sure that you can mix between classic job descriptions and pipeline projects.

What is not yet working: surviving Jenkins restarts. For us/me, this is not a requirement, but I am willing to add support for this too if someone provides me the necessary pointers (I already tried, but my knowledge of Jenkins plugin interna is very limited).