### PR TITLE
Require Jenkins 2.346.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,8 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.424</version>
+    <version>4.51</version>
+    <relativePath />
   </parent>
 
   <artifactId>port-allocator</artifactId>
@@ -11,6 +12,10 @@
   <version>1.9-SNAPSHOT</version>
   <name>Jenkins Port Allocator Plug-in</name>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Port+Allocator+Plugin</url>
+
+  <properties>
+    <jenkins.version>2.346.3</jenkins.version>
+  </properties>
 
   <developers>
     <developer>
@@ -37,13 +42,6 @@
     <url>https://github.com/jenkinsci/port-allocator-plugin</url>
   </scm>
 
-    <distributionManagement>
-        <repository>
-            <id>maven.jenkins-ci.org</id>
-            <url>http://maven.jenkins-ci.org:8081/content/repositories/releases/</url>
-        </repository>
-    </distributionManagement>
-
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
@@ -58,13 +56,24 @@
         </pluginRepository>
     </pluginRepositories>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-all</artifactId>
-        <version>1.9.0-rc1</version>
-        <type>jar</type>
-        <scope>test</scope>
-      </dependency>
+        <dependency>
+            <groupId>io.jenkins.tools.bom</groupId>
+            <artifactId>bom-2.346.x</artifactId>
+            <version>1750.v0071fa_4c4a_e3</version>
+            <scope>import</scope>
+            <type>pom</type>
+        </dependency>
     </dependencies>
+  </dependencyManagement>
+
 </project>  

--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,8 @@
   </developers>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/port-allocator-plugin.git</connection>
-    <developerConnection>scm:git:ssh://git@github.com/jenkinsci/port-allocator-plugin.git</developerConnection>
+    <connection>scm:git:https://github.com/jenkinsci/port-allocator-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/port-allocator-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/port-allocator-plugin</url>
   </scm>
 

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/GlassFishJmxPortType.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/GlassFishJmxPortType.java
@@ -118,7 +118,10 @@ public class GlassFishJmxPortType extends PortType {
 
             public void cleanUp() throws IOException, InterruptedException {
                 manager.free(n);
-                launcher.getChannel().call(new GlassFishCleanUpTask(buildListener));
+                hudson.remoting.VirtualChannel channel = launcher.getChannel();
+                if (channel != null) {
+                    channel.call(new GlassFishCleanUpTask(buildListener));
+                }
             }
         };
     }

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/GlassFishJmxPortType.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/GlassFishJmxPortType.java
@@ -65,6 +65,11 @@ public class GlassFishJmxPortType extends PortType {
                 this.buildListener = buildListener;
             }
 
+            @Override
+            public void checkRoles(final org.jenkinsci.remoting.RoleChecker checker) throws SecurityException {
+                checker.check(this, jenkins.security.Roles.SLAVE);
+            }
+
             public Void call() throws IOException {
                 JMXServiceURL url = new JMXServiceURL("service:jmx:rmi:///jndi/rmi://localhost:"+ n +"/jmxrmi");
 

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/PoolNotDefinedException.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/PoolNotDefinedException.java
@@ -3,5 +3,5 @@ package org.jvnet.hudson.plugins.port_allocator;
 /**
  * @author pepov
  */
-public class PoolNotDefinedException extends Throwable {
+public class PoolNotDefinedException extends Exception {
 }

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortAllocationManager.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortAllocationManager.java
@@ -33,6 +33,8 @@ public final class PortAllocationManager {
     private static final Map<Computer, WeakReference<PortAllocationManager>> INSTANCES =
             new WeakHashMap<Computer, WeakReference<PortAllocationManager>>();
 
+    private static final Random rnd = new Random();
+
     private PortAllocationManager(Computer node) {
         this.node = node;
     }
@@ -81,7 +83,6 @@ public final class PortAllocationManager {
         int[] allocated = new int[count];
 
         boolean allocationFailed = true;
-        Random rnd = new Random();
 
         // Attempt the whole allocation a few times using a brute force approach.
         for (int trynum = 0; (allocationFailed && (trynum < MAX_TRIES)); trynum++) {
@@ -251,6 +252,11 @@ public final class PortAllocationManager {
             int localPort = server.getLocalPort();
             server.close();
             return localPort;
+        }
+
+        @Override
+        public void checkRoles(final org.jenkinsci.remoting.RoleChecker checker) throws SecurityException {
+            checker.check(this, jenkins.security.Roles.SLAVE);
         }
 
         private static final long serialVersionUID = 1L;

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortAllocator.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortAllocator.java
@@ -43,12 +43,21 @@ public class PortAllocator extends BuildWrapper
         final Executor currentExecutor = Executor.currentExecutor();
         if (currentExecutor == null) {
             logger.println("No current executor for port allocator, exiting setUp");
-            return;
+            return new Environment() {
+                @Override
+                public void buildEnvVars(Map<String, String> env) {
+                }
+                @Override
+                public boolean tearDown(AbstractBuild build, BuildListener listener) throws IOException, InterruptedException {
+                    return true;
+                }
+            };
         }
         final Computer cur = currentExecutor.getOwner();
         Map<String,Integer> prefPortMap = new HashMap<String,Integer>();
-        if (build.getPreviousBuild() != null) {
-            AllocatedPortAction prevAlloc = build.getPreviousBuild().getAction(AllocatedPortAction.class);
+        AbstractBuild previousBuild = build.getPreviousBuild();
+        if (previousBuild != null) {
+            AllocatedPortAction prevAlloc = previousBuild.getAction(AllocatedPortAction.class);
             if (prevAlloc != null) {
                 // try to assign ports assigned in previous build
                 prefPortMap = prevAlloc.getPreviousAllocatedPorts();

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortAllocator.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortAllocator.java
@@ -40,7 +40,12 @@ public class PortAllocator extends BuildWrapper
     public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
         PrintStream logger = listener.getLogger();
 
-        final Computer cur = Executor.currentExecutor().getOwner();
+        final Executor currentExecutor = Executor.currentExecutor();
+        if (currentExecutor == null) {
+            logger.println("No current executor for port allocator, exiting setUp");
+            return;
+        }
+        final Computer cur = currentExecutor.getOwner();
         Map<String,Integer> prefPortMap = new HashMap<String,Integer>();
         if (build.getPreviousBuild() != null) {
             AllocatedPortAction prevAlloc = build.getPreviousBuild().getAction(AllocatedPortAction.class);

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortTypeDescriptor.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortTypeDescriptor.java
@@ -1,5 +1,7 @@
 package org.jvnet.hudson.plugins.port_allocator;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import hudson.model.Descriptor;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -19,5 +21,7 @@ public abstract class PortTypeDescriptor extends Descriptor<PortType> {
     /**
      * All registered {@link PortTypeDescriptor}s.
      */
+    @SuppressFBWarnings(value = "MS_MUTABLE_COLLECTION_PKGPROTECT",
+                        justification = "Low risk to leave it visible outside the package")
     public static final List<PortTypeDescriptor> LIST = new ArrayList<PortTypeDescriptor>();
 }

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/TomcatShutdownPortType.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/TomcatShutdownPortType.java
@@ -1,5 +1,7 @@
 package org.jvnet.hudson.plugins.port_allocator;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
@@ -10,6 +12,7 @@ import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.io.UnsupportedEncodingException;
 import java.net.Socket;
 
 /**
@@ -49,6 +52,17 @@ public class TomcatShutdownPortType  extends PortType {
                 checker.check(this, jenkins.security.Roles.SLAVE);
             }
 
+            @SuppressFBWarnings(value = "DM_DEFAULT_ENCODING",
+                                justification = "Read UTF-8 as first preference")
+            private byte[] getBytes(String s) {
+                byte[] bytes;
+                try {
+                    return s.getBytes("UTF-8");
+                } catch (UnsupportedEncodingException e) {
+                    return s.getBytes();
+                }
+            }
+
             public Void call() throws IOException {
                 Socket s;
                 try {
@@ -59,7 +73,7 @@ public class TomcatShutdownPortType  extends PortType {
                 }
 
                 try {
-                    s.getOutputStream().write(password.getBytes());
+                    s.getOutputStream().write(getBytes(password));
                     s.close();
                     buildListener.getLogger().println("Shutdown left-over Tomcat");
                 } catch (IOException x) {

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/TomcatShutdownPortType.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/TomcatShutdownPortType.java
@@ -44,6 +44,11 @@ public class TomcatShutdownPortType  extends PortType {
                 this.buildListener = buildListener;
             }
 
+            @Override
+            public void checkRoles(final org.jenkinsci.remoting.RoleChecker checker) throws SecurityException {
+                checker.check(this, jenkins.security.Roles.SLAVE);
+            }
+
             public Void call() throws IOException {
                 Socket s;
                 try {

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/TomcatShutdownPortType.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/TomcatShutdownPortType.java
@@ -92,7 +92,10 @@ public class TomcatShutdownPortType  extends PortType {
 
             public void cleanUp() throws IOException, InterruptedException {
                 manager.free(n);
-                launcher.getChannel().call(new TomcatCleanUpTask(buildListener));
+                hudson.remoting.VirtualChannel channel = launcher.getChannel();
+                if (channel != null) {
+                    channel.call(new TomcatCleanUpTask(buildListener));
+                }
             }
         };
     }

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -3,6 +3,7 @@
 
   Since we don't really have anything dynamic here, let's just use static HTML. 
 -->
+<?jelly escape-by-default='true'?>
 <div>
   This plugin allocates free ports as environment variables.
 </div>

--- a/src/main/resources/org/jvnet/hudson/plugins/port_allocator/DefaultPortType/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/port_allocator/DefaultPortType/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="Name" help="/plugin/port-allocator/help-name.html">
     <f:textbox name="portType.name" value="${instance.name}" />

--- a/src/main/resources/org/jvnet/hudson/plugins/port_allocator/GlassFishJmxPortType/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/port_allocator/GlassFishJmxPortType/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="Name" help="/plugin/port-allocator/help-name.html">
     <f:textbox name="portType.name" value="${h.defaulted(instance.name,'JMX_PORT')}" />

--- a/src/main/resources/org/jvnet/hudson/plugins/port_allocator/PooledPortType/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/port_allocator/PooledPortType/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly
         xmlns:j="jelly:core"
         xmlns:st="jelly:stapler"

--- a/src/main/resources/org/jvnet/hudson/plugins/port_allocator/PortAllocator/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/port_allocator/PortAllocator/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:block>
     <f:hetero-list name="ports" descriptors="${descriptor.portTypes}" items="${instance.ports}" />

--- a/src/main/resources/org/jvnet/hudson/plugins/port_allocator/PortAllocator/global.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/port_allocator/PortAllocator/global.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"
          xmlns:st="jelly:stapler"
          xmlns:d="jelly:define"

--- a/src/main/resources/org/jvnet/hudson/plugins/port_allocator/TomcatShutdownPortType/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/port_allocator/TomcatShutdownPortType/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="Name" help="/plugin/port-allocator/help-name.html">
     <f:textbox name="portType.name" value="${h.defaulted(instance.name,'SHUTDOWN_PORT')}" />

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<FindBugsFilter>
+  <!--
+    Exclusions in this section have been triaged and determined to be
+    false positives.
+  -->
+  <Match>
+    <Bug pattern="SE_INNER_CLASS"/>
+    <Or>
+      <Class name="org.jvnet.hudson.plugins.port_allocator.GlassFishJmxPortType$1GlassFishCleanUpTask"/>
+      <Class name="org.jvnet.hudson.plugins.port_allocator.TomcatShutdownPortType$1TomcatCleanUpTask"/>
+    </Or>
+  </Match>
+
+  <!--
+    Here lies technical debt. Exclusions in this section have not yet
+    been triaged. When working on this section, pick an exclusion to
+    triage, then:
+
+    - Add a @SuppressFBWarnings(value = "[...]", justification = "[...]")
+      annotation if it is a false positive.  Indicate the reason why
+      it is a false positive, then remove the exclusion from this
+      section.
+
+    - If it is not a false positive, fix the bug, then remove the
+      exclusion from this section.
+   -->
+</FindBugsFilter>

--- a/src/test/java/org/jvnet/hudson/plugins/port_allocator/PortAllocationManagerTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/port_allocator/PortAllocationManagerTest.java
@@ -119,7 +119,7 @@ public class PortAllocationManagerTest extends TestCase {
 
 		final int mockPort = 42;
 		Mockito.when(computer.getChannel()).thenReturn(channel);
-		Mockito.when(channel.call(Mockito.isNotNull(Callable.class))).thenReturn(mockPort);
+		Mockito.when(channel.call(Mockito.isNotNull())).thenReturn(mockPort);
 
 		final PortAllocationManager manager = PortAllocationManager.getManager(computer);
 
@@ -148,7 +148,7 @@ public class PortAllocationManagerTest extends TestCase {
 		final int mockPort = 44;
 		Mockito.when(computer.getChannel()).thenReturn(channel);
 
-		Mockito.when(channel.call(Mockito.isNotNull(Callable.class)))
+		Mockito.when(channel.call(Mockito.isNotNull()))
 								// First port succeeds
 								.thenReturn(mockPort)
 								// Second port fails


### PR DESCRIPTION
## Require Jenkins 2.346.3 or newer

Modernize the plugin to use a recent parent pom and Jenkins 2.346.3 as its minimum Jenkins version.

- Escape jelly content by default
- Implement checkRoles
- Adapt to most recent mockito
- Fix the scm URLs in pom
- Extend Exception for pool not defined exception
- Suppress default encoding spotbugs warning
- Prevent NPE in GlassFishJMXPortType cleanUp
- Prevent NPE in PortAllocator
- Avoid PortAllocator null pointer exceptions
- Avoid NPE in TomcatShutdownPortType
- Suppress spotbugs warning on mutable collection
- Suppress spotbugs inner class warning
- Require Jenkins 2.346.3 or newer

This intentionally did not make the switch to require Java 11 and Jenkins 2.361.4 or newer.  Many of the installations of this plugin are on very old Jenkins versions.  They may need the flexibility to decide if they upgrade to 2.346.3 (Java 8) or 2.375.1 (Java 11).

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
