### PR TITLE
Use jenkins.baseline to match archetype

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,12 @@
-# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates
----
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates
+
 version: 2
 updates:
-  - package-ecosystem: "maven"
-    directory: "/"
-    labels:
-      - "dependencies"
-    schedule:
-      interval: "monthly"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    labels:
-      - "skip-changelog"
-    schedule:
-      interval: "monthly"
+- package-ecosystem: maven
+  directory: /
+  schedule:
+    interval: monthly
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: monthly

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,8 @@
   <url>https://github.com/jenkinsci/port-allocator-plugin</url>
 
   <properties>
-    <jenkins.version>2.375.4</jenkins.version>
+    <jenkins.baseline>2.375</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
   </properties>
 
   <developers>
@@ -69,7 +70,7 @@
     <dependencies>
         <dependency>
             <groupId>io.jenkins.tools.bom</groupId>
-            <artifactId>bom-2.375.x</artifactId>
+            <artifactId>bom-${jenkins.baseline}.x</artifactId>
             <version>2198.v39c76fc308ca</version>
             <scope>import</scope>
             <type>pom</type>


### PR DESCRIPTION
## Use jenkins.baseline to match archetype

The Jenkins plugin archetype uses jenkins.baseline to prevent inconsistencies between the minimum required Jenkins version and the Jenkins plugin bill of materials version.  Use the same technique in this plugin.

### Testing done

Confirmed that compilation passes.  Will rely on ci.jenkins.io to check automated tests.  Behavior preserving transformation.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
