### PR TITLE
Require Jenkins 2.479.1 or newer and Jakarta EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.6</version>
     <relativePath />
   </parent>
 
@@ -14,28 +14,9 @@
   <url>https://github.com/jenkinsci/port-allocator-plugin</url>
 
   <properties>
-    <jenkins.baseline>2.452</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
   </properties>
-
-  <developers>
-    <developer>
-      <id>ramapulavarthi</id>
-      <name>Rama Pulavarthi</name>
-    </developer>
-    <developer>
-      <id>kohsuke</id>
-      <name>Kohsuke Kawaguchi</name>
-    </developer>
-    <developer>
-      <id>oldelvet</id>
-      <name>Richard Mortimer</name>
-    </developer>
-    <developer>
-      <id>pepov</id>
-      <name>Peter Wilcsinszky</name>
-    </developer>
-  </developers>
 
   <scm>
     <connection>scm:git:https://github.com/jenkinsci/port-allocator-plugin.git</connection>
@@ -71,7 +52,7 @@
         <dependency>
             <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-	    <version>3944.v1a_e4f8b_452db_</version>
+	    <version>4051.v78dce3ce8b_d6</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/DefaultPortType.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/DefaultPortType.java
@@ -5,7 +5,7 @@ import hudson.model.BuildListener;
 import hudson.Launcher;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 import java.io.IOException;
 
@@ -49,7 +49,7 @@ public class DefaultPortType extends PortType {
             super(DefaultPortType.class);
         }
 
-        public DefaultPortType newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+        public DefaultPortType newInstance(StaplerRequest2 req, JSONObject formData) throws FormException {
             // TODO: we need form binding from JSON
             return new DefaultPortType(formData.getString("name"));
         }

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/GlassFishJmxPortType.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/GlassFishJmxPortType.java
@@ -18,6 +18,7 @@ import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
 import java.io.IOException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.net.ConnectException;
 import java.net.SocketException;
@@ -108,6 +109,7 @@ public class GlassFishJmxPortType extends PortType {
                 return null;
             }
 
+            @Serial
             private static final long serialVersionUID = 1L;
         }
 
@@ -150,6 +152,7 @@ public class GlassFishJmxPortType extends PortType {
         public static final DescriptorImpl INSTANCE = new DescriptorImpl();
     }
 
+    @Serial
     private static final long serialVersionUID = 1L;
 }
 

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/GlassFishJmxPortType.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/GlassFishJmxPortType.java
@@ -6,7 +6,7 @@ import hudson.model.BuildListener;
 import hudson.remoting.Callable;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanException;
@@ -135,7 +135,7 @@ public class GlassFishJmxPortType extends PortType {
             super(GlassFishJmxPortType.class);
         }
 
-        public GlassFishJmxPortType newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+        public GlassFishJmxPortType newInstance(StaplerRequest2 req, JSONObject formData) throws FormException {
             // TODO: we need form binding from JSON
             return new GlassFishJmxPortType(
                 formData.getString("name"),

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/PooledPortType.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/PooledPortType.java
@@ -7,7 +7,7 @@ import hudson.model.BuildListener;
 import hudson.util.ListBoxModel;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 import java.io.IOException;
 
@@ -70,7 +70,7 @@ public class PooledPortType extends PortType {
             super(PooledPortType.class);
         }
 
-        public PooledPortType newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+        public PooledPortType newInstance(StaplerRequest2 req, JSONObject formData) throws FormException {
 
             if ("".equals(formData.getString("name"))) {
                 throw new FormException(

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortAllocator.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortAllocator.java
@@ -9,7 +9,7 @@ import net.sf.json.JSONObject;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -132,7 +132,7 @@ public class PortAllocator extends BuildWrapper
         }
 
         @Override
-        public BuildWrapper newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+        public BuildWrapper newInstance(StaplerRequest2 req, JSONObject formData) throws FormException {
             List<PortType> ports = Descriptor.newInstancesFromHeteroList(
                     req, formData, "ports", PortTypeDescriptor.LIST);
 
@@ -148,7 +148,7 @@ public class PortAllocator extends BuildWrapper
         }
 
         @Override
-        public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
+        public boolean configure(StaplerRequest2 req, JSONObject formData) throws FormException {
             Pool[] pools = req.bindParametersToList(Pool.class, "pool.").toArray(new Pool[] {});
             for (Pool p : pools) {
                 p.name = checkPoolName(p.name);

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortType.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortType.java
@@ -7,6 +7,7 @@ import hudson.model.Describable;
 import hudson.model.BuildListener;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -64,5 +65,6 @@ public abstract class PortType implements ExtensionPoint, Describable<PortType>,
 
     public abstract PortTypeDescriptor getDescriptor();
 
+    @Serial
     private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortTypeDescriptor.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortTypeDescriptor.java
@@ -3,7 +3,7 @@ package org.jvnet.hudson.plugins.port_allocator;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import hudson.model.Descriptor;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/TomcatShutdownPortType.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/TomcatShutdownPortType.java
@@ -11,6 +11,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest2;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.net.Socket;
@@ -82,6 +83,7 @@ public class TomcatShutdownPortType  extends PortType {
                 return null;
             }
 
+            @Serial
             private static final long serialVersionUID = 1L;
         }
 
@@ -123,6 +125,7 @@ public class TomcatShutdownPortType  extends PortType {
         public static final DescriptorImpl INSTANCE = new DescriptorImpl();
     }
 
+    @Serial
     private static final long serialVersionUID = 1L;
 }
 

--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/TomcatShutdownPortType.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/TomcatShutdownPortType.java
@@ -8,7 +8,7 @@ import hudson.model.BuildListener;
 import hudson.remoting.Callable;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -109,7 +109,7 @@ public class TomcatShutdownPortType  extends PortType {
             super(TomcatShutdownPortType.class);
         }
 
-        public TomcatShutdownPortType newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+        public TomcatShutdownPortType newInstance(StaplerRequest2 req, JSONObject formData) throws FormException {
             // TODO: we need form binding from JSON
             return new TomcatShutdownPortType(
                 formData.getString("name"),


### PR DESCRIPTION
## Require Jenkins 2.479.1 or newer and Jakarta EE 9

Jenkins 2.479.1 provides Jakarta EE 9 and requires Java 17.

### Testing done

Confirmed that the android emulator plugin is not affected by the API changes in this pull request.  It is the only plugin that is dependent on this plugin.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
